### PR TITLE
Dockerfile update to include Maven build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,11 @@
+FROM alpine:latest as build
+WORKDIR /opt/api_interview_eoc
+COPY . .
+RUN apk update \
+    && apk add maven \
+    && mvn clean install -DskipTests
+
 FROM adoptopenjdk/openjdk11:latest
-COPY "./target/api_interview_eoc-0.0.1-SNAPSHOT.jar" "app.jar"
+COPY --from=build /opt/api_interview_eoc/target/api_interview_eoc-0.0.1-SNAPSHOT.jar app.jar
 EXPOSE 8080
 ENTRYPOINT ["java","-jar","app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM adoptopenjdk/openjdk11:latest
+COPY "./target/api_interview_eoc-0.0.1-SNAPSHOT.jar" "app.jar"
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","app.jar"]

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can use Intellij to open the project and run it.
 ## Building
 
 ```
-$ mvn clean install
+$ mvn clean install -DskipTests
 ```
 
 ## Running

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ You can use Intellij to open the project and run it.
 
 ## Run using Docker
 
-on the path of the project run the next commands using the terminal:
-```
-mvn clean install -DskipTests
+You must have [Docker Desktop](https://www.docker.com/products/docker-desktop/) installed.
 
+On the path of the project run the next commands using the terminal:
+```
 docker build -t spring-boot-docker .
 
-docker run -p 8080:8080 spring-boot-docker
+docker run --name crodriguez_codechallenge -p 8080:8080 spring-boot-docker
 ```
 
 After that you can visit the swagger page to tests the endpoints:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ swagger-ui: http://localhost:8080/swagger-ui.html
 
 This project uses Maven for builds.
 You need Java 11 installed.
+You can use Intellij to open the project and run it.
 
 
 ## Building

--- a/README.md
+++ b/README.md
@@ -25,6 +25,21 @@ This project uses Maven for builds.
 You need Java 11 installed.
 You can use Intellij to open the project and run it.
 
+## Run using Docker
+
+on the path of the project run the next commands using the terminal:
+```
+mvn clean install -DskipTests
+
+docker build -t spring-boot-docker .
+
+docker run -p 8080:8080 spring-boot-docker
+```
+
+After that you can visit the swagger page to tests the endpoints:
+
+http://localhost:8080/swagger-ui.html
+
 
 ## Building
 


### PR DESCRIPTION
Hi Christian! The original Dockerfile still presumes that Maven is installed locally.
The change adds a build stage and then adds the build artifact to the final image.
I also updated the README.
This works for me, and I'm able to run your app locally.